### PR TITLE
Do not print traceback when exiting with Ctrl+C

### DIFF
--- a/asyncchat.py
+++ b/asyncchat.py
@@ -264,4 +264,7 @@ if __name__ == "__main__":
         host = '127.0.0.1'
         port = 2323
     server = Server(host, port)
-    server.run_forever()
+    try:
+        server.run_forever()
+    except KeyboardInterrupt:
+        print('')


### PR DESCRIPTION
There is no need of showing the traceback when exiting the server with Ctrl+C

I know that this is a demo server and not for production use but if someone which is new to Python run it and see the traceback can be confusing.